### PR TITLE
Obs_Node.out file uses 'Flux' column name instead of 'Temp'

### DIFF
--- a/phydrus/read.py
+++ b/phydrus/read.py
@@ -259,7 +259,7 @@ def read_obs_node(path="OBS_NODE.OUT", nodes=None, conc=False, cols=None):
     df1 = read_csv(path, skiprows=start, index_col=0, nrows=end - start - 1,
                    skipinitialspace=True, delim_whitespace=True, engine="c")
     if cols is None:
-        cols = ["h", "theta", "Temp"]
+        cols = ["h", "theta", "Flux"]
     if conc:
         cols.append("Conc")
 


### PR DESCRIPTION
I am using Hydrus1D version 4.17.0140. However, there was an error when trying to use ".read_obs_node()" I was getting an error with the "Temp". Changing to "Flux" for this version seems to work.